### PR TITLE
Buffer size fixes

### DIFF
--- a/src/2x2contingency/random_set/go_graph.cc
+++ b/src/2x2contingency/random_set/go_graph.cc
@@ -20,19 +20,19 @@ go_graph::go_graph( set<string> &nodes, istream &term2term, idmap &idm_ )
 	// read term2term file, create graph
 	while ( term2term ) {
 		// 4 rows, 1 a id, 2 type of relationship, 3 parent, 4 child
-		char s1[20] ;
+		char s1[20000] ;
 
-		term2term.getline( s1, 20, '\t' ) ;
-		term2term.getline( s1, 20, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
 
 
 		// parent id
-		term2term.getline( s1, 20, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
 
 		map<string, go_obj*>::const_iterator par = temp_graph.find( s1 ) ;
 		if ( par != temp_graph.end() ) {
 			// child id
-			term2term.getline( s1, 20, '\n' ) ;
+			term2term.getline( s1, 20000, '\n' ) ;
 			string str_s1( s1 ) ;
 			string child_id ;
 			string::size_type tab_pos = str_s1.find( '\t' ) ;

--- a/src/binomial/random_set/go_graph.cc
+++ b/src/binomial/random_set/go_graph.cc
@@ -24,12 +24,12 @@ go_graph::go_graph( set<string> &nodes, istream &term2term, idmap &idm_ )
 		char s1[20] ;
 
 		// skip first 2 columns
-		term2term.getline( s1, 20, '\t' ) ;
-		term2term.getline( s1, 20, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
 
 
 		// parent id
-		term2term.getline( s1, 20, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
 
 		/* The format of the term_db_tables has changed in 12.2004. 
 		   a new column appeared in the term2term table. So we have to check
@@ -39,7 +39,7 @@ go_graph::go_graph( set<string> &nodes, istream &term2term, idmap &idm_ )
 		map<string, go_obj*>::const_iterator par = temp_graph.find( s1 ) ;
 		if ( par != temp_graph.end() ) {
 			// child id
-			term2term.getline( s1, 20, '\n' ) ;
+			term2term.getline( s1, 20000, '\n' ) ;
 			string str_s1( s1 ) ;
 			string child_id ;
 			string::size_type tab_pos = str_s1.find( '\t' ) ;
@@ -54,7 +54,7 @@ go_graph::go_graph( set<string> &nodes, istream &term2term, idmap &idm_ )
 			}	
 		} else {
 			// skip rest if the parent node is not part of the graph
-			term2term.getline( s1, 20, '\n' ) ;
+			term2term.getline( s1, 20000, '\n' ) ;
 		}
 	}
 	// rewrite map file because detectedfile has

--- a/src/binomial/random_set/go_graph.cc
+++ b/src/binomial/random_set/go_graph.cc
@@ -21,7 +21,7 @@ go_graph::go_graph( set<string> &nodes, istream &term2term, idmap &idm_ )
 	while ( term2term ) {
 		// 4 columns, 1 a id, 2 type of relationship, 3 parent, 4 child
 		// new format: 5 col. Last column: 5 "complete"
-		char s1[20] ;
+		char s1[20000] ;
 
 		// skip first 2 columns
 		term2term.getline( s1, 20000, '\t' ) ;

--- a/src/binomial/refinement/go_graph.cc
+++ b/src/binomial/refinement/go_graph.cc
@@ -22,17 +22,17 @@ go_graph::go_graph( set<string> &nodes, istream &term2term, idmap &idm_, int co 
 		// 4 rows, 1 a id, 2 type of relationship, 3 parent, 4 child
 		char s1[20] ;
 
-		term2term.getline( s1, 20, '\t' ) ;
-		term2term.getline( s1, 20, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
 
 
 		// parent id
-		term2term.getline( s1, 20, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
 
 		map<string, go_obj*>::const_iterator par = temp_graph.find( s1 ) ;
 		if ( par != temp_graph.end() ) {
 			// child id
-			term2term.getline( s1, 20, '\n' ) ;
+			term2term.getline( s1, 20000, '\n' ) ;
 			string str_s1( s1 ) ;
 			string child_id ;
 			string::size_type tab_pos = str_s1.find( '\t' ) ;
@@ -47,7 +47,7 @@ go_graph::go_graph( set<string> &nodes, istream &term2term, idmap &idm_, int co 
 			}	
 		} else {
 			// skip rest if the parent node is not part of the graph
-			term2term.getline( s1, 20, '\n' ) ;
+			term2term.getline( s1, 20000, '\n' ) ;
 		}
 	}
 	// rewrite map file because detectedfile has

--- a/src/common/idmap.h
+++ b/src/common/idmap.h
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <string>
 #include <map>
-#define MAX_LINE_LENGTH_TERMS 200 
+#define MAX_LINE_LENGTH_TERMS 20000 
 
 using std::string;
 using std::istream;

--- a/src/hypergeometric/random_set/go_graph.cc
+++ b/src/hypergeometric/random_set/go_graph.cc
@@ -35,19 +35,19 @@ go_graph::go_graph( set<string> &nodes, istream &term2term, idmap &idm_ )
 	// read term2term file, create graph
 	while ( term2term ) {
 		// 4 rows, 1 a id, 2 type of relationship, 3 parent, 4 child
-		char s1[20] ;
+		char s1[20000] ;
 
-		term2term.getline( s1, 20, '\t' ) ;
-		term2term.getline( s1, 20, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
 
 
 		// parent id
-		term2term.getline( s1, 20, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
 
 		map<string, go_obj*>::const_iterator par = temp_graph.find( s1 ) ;
 		if ( par != temp_graph.end() ) {
 			// child id
-			term2term.getline( s1, 20, '\n' ) ;
+			term2term.getline( s1, 20000, '\n' ) ;
 			string str_s1( s1 ) ;
 			string child_id ;
 			string::size_type tab_pos = str_s1.find( '\t' ) ;
@@ -62,7 +62,7 @@ go_graph::go_graph( set<string> &nodes, istream &term2term, idmap &idm_ )
 			}	
 		} else {
 			// skip rest if the parent node is not part of the graph
-			term2term.getline( s1, 20, '\n' ) ;
+			term2term.getline( s1, 20000, '\n' ) ;
 		}
 	}
 	// rewrite map file because detectedfile has

--- a/src/hypergeometric/refinement/go_graph.cc
+++ b/src/hypergeometric/refinement/go_graph.cc
@@ -37,17 +37,17 @@ go_graph::go_graph( set<string> &nodes, istream &term2term, idmap &idm_ )
 		// 4 rows, 1 a id, 2 type of relationship, 3 parent, 4 child
 		char s1[20] ;
 
-		term2term.getline( s1, 20, '\t' ) ;
-		term2term.getline( s1, 20, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
 
 
 		// parent id
-		term2term.getline( s1, 20, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
 
 		map<string, go_obj*>::const_iterator par = temp_graph.find( s1 ) ;
 		if ( par != temp_graph.end() ) {
 			// child id
-			term2term.getline( s1, 20, '\n' ) ;
+			term2term.getline( s1, 20000, '\n' ) ;
 			string str_s1( s1 ) ;
 			string child_id ;
 			string::size_type tab_pos = str_s1.find( '\t' ) ;
@@ -62,7 +62,7 @@ go_graph::go_graph( set<string> &nodes, istream &term2term, idmap &idm_ )
 			}	
 		} else {
 			// skip rest if the parent node is not part of the graph
-			term2term.getline( s1, 20, '\n' ) ;
+			term2term.getline( s1, 20000, '\n' ) ;
 		}
 		
 	}

--- a/src/wilcoxon/random_set/go_graph.cc
+++ b/src/wilcoxon/random_set/go_graph.cc
@@ -24,12 +24,12 @@ go_graph::go_graph( set<string> &nodes, istream &term2term, idmap &idm_ )
 		char s1[20] ;
 
 		// skip first 2 columns
-		term2term.getline( s1, 20, '\t' ) ;
-		term2term.getline( s1, 20, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
 
 
 		// parent id
-		term2term.getline( s1, 20, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
 
 		/* The format of the term_db_tables has changed in 12.2004. 
 		   a new column appeared in the term2term table. So we have to check
@@ -39,7 +39,7 @@ go_graph::go_graph( set<string> &nodes, istream &term2term, idmap &idm_ )
 		map<string, go_obj*>::const_iterator par = temp_graph.find( s1 ) ;
 		if ( par != temp_graph.end() ) {
 			// child id
-			term2term.getline( s1, 20, '\n' ) ;
+			term2term.getline( s1, 20000, '\n' ) ;
 			string str_s1( s1 ) ;
 			string child_id ;
 			string::size_type tab_pos = str_s1.find( '\t' ) ;
@@ -54,7 +54,7 @@ go_graph::go_graph( set<string> &nodes, istream &term2term, idmap &idm_ )
 			}	
 		} else {
 			// skip rest if the parent node is not part of the graph
-			term2term.getline( s1, 20, '\n' ) ;
+			term2term.getline( s1, 20000, '\n' ) ;
 		}
 	}
 	// rewrite map file because detectedfile has

--- a/src/wilcoxon/random_set/go_graph.cc
+++ b/src/wilcoxon/random_set/go_graph.cc
@@ -21,7 +21,7 @@ go_graph::go_graph( set<string> &nodes, istream &term2term, idmap &idm_ )
 	while ( term2term ) {
 		// 4 columns, 1 a id, 2 type of relationship, 3 parent, 4 child
 		// new format: 5 col. Last column: 5 "complete"
-		char s1[20] ;
+		char s1[20000] ;
 
 		// skip first 2 columns
 		term2term.getline( s1, 20000, '\t' ) ;

--- a/src/wilcoxon/refinement/go_graph.cc
+++ b/src/wilcoxon/refinement/go_graph.cc
@@ -22,17 +22,17 @@ go_graph::go_graph( set<string> &nodes, istream &term2term, idmap &idm_, int co 
 		// 4 rows, 1 a id, 2 type of relationship, 3 parent, 4 child
 		char s1[20] ;
 
-		term2term.getline( s1, 20, '\t' ) ;
-		term2term.getline( s1, 20, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
 
 
 		// parent id
-		term2term.getline( s1, 20, '\t' ) ;
+		term2term.getline( s1, 20000, '\t' ) ;
 
 		map<string, go_obj*>::const_iterator par = temp_graph.find( s1 ) ;
 		if ( par != temp_graph.end() ) {
 			// child id
-			term2term.getline( s1, 20, '\n' ) ;
+			term2term.getline( s1, 20000, '\n' ) ;
 			string str_s1( s1 ) ;
 			string child_id ;
 			string::size_type tab_pos = str_s1.find( '\t' ) ;
@@ -47,7 +47,7 @@ go_graph::go_graph( set<string> &nodes, istream &term2term, idmap &idm_, int co 
 			}	
 		} else {
 			// skip rest if the parent node is not part of the graph
-			term2term.getline( s1, 20, '\n' ) ;
+			term2term.getline( s1, 20000, '\n' ) ;
 		}
 	}
 	// rewrite map file because detectedfile has


### PR DESCRIPTION
The patches increase buffer size throughout func; buffer sizes may be sufficient for use in GO, but will not work with ontologies using longer IDs or full URIs (currently ID size limited to 20 chars), and in ontologies with long labels (>200); increased both ID length and label length to 20000 chars.